### PR TITLE
Format Slack slash command response

### DIFF
--- a/src/app/responders/common/cal.py
+++ b/src/app/responders/common/cal.py
@@ -2,10 +2,10 @@ import calendar
 
 import datetime
 
-from app.responders.slack import SlackResponder
+from app.responders.slack import SlackCommandResponder
 
 
-class CalSlackResponder(SlackResponder):
+class CalSlackResponder(SlackCommandResponder):
 
     def process(self, args):
         """

--- a/src/app/responders/common/cal.py
+++ b/src/app/responders/common/cal.py
@@ -7,6 +7,8 @@ from app.responders.slack import SlackCommandResponder
 
 class CalSlackResponder(SlackCommandResponder):
 
+    RESPONSE_TYPE = "in_channel"
+
     def process(self, args):
         """
         Return a pretty-printed monthly calendar

--- a/src/app/responders/slack/__init__.py
+++ b/src/app/responders/slack/__init__.py
@@ -110,4 +110,6 @@ class SlackCommandResponder(RequestHandler, BaseResponder):
         """
         return []
 
+    def prepare_string(args):
+        pass
 

--- a/src/app/responders/slack/__init__.py
+++ b/src/app/responders/slack/__init__.py
@@ -41,3 +41,73 @@ class SlackResponder(RequestHandler, BaseResponder):
         if trigger_word.rfind(':') == -1:
             trigger_word += ':'
         return args['text'].split(trigger_word)[1].strip()
+
+
+class SlackCommandResponder(RequestHandler, BaseResponder):
+    """
+    Base responder for Slacks' custom integration slash commands
+    """
+    RESPONSE_TYPE = None # Set to "in_channel" for response & message to be shared in channel
+
+    def post(self):
+        """ POST """
+        token = self.request.POST.get('token')
+        if not token:
+            self.abort(401)
+
+        if self.check_credentials(token):
+            response = {
+                "text": self.process(self.request.POST)
+            }
+            attachment = self.build_attachment()
+            if self.RESPONSE_TYPE:
+                response["response_type"] = self.RESPONSE_TYPE
+            if attachment:
+                response["attachment"] = attachment
+            self.render_response(response)
+        else:
+            self.abort(401)
+
+    def process(self, args):
+        """ process """
+        raise NotImplementedError()
+
+    @classmethod
+    def check_credentials(cls, token):
+        return token in cls.TOKENS['slack']
+
+    def render_response(self, args):
+        pass
+
+    def build_attachment(self):
+        """
+        Build list of attachments as follows:
+        [
+            {
+                "fallback": "Required plain-text summary of the attachment.",
+                "color": "#36a64f",
+                "pretext": "Optional text that appears above the attachment block",
+                "author_name": "Bobby Tables",
+                "author_link": "http://flickr.com/bobby/",
+                "author_icon": "http://flickr.com/icons/bobby.jpg",
+                "title": "Slack API Documentation",
+                "title_link": "https://api.slack.com/",
+                "text": "Optional text that appears within the attachment",
+                "fields": [
+                    {
+                        "title": "Priority",
+                        "value": "High",
+                        "short": false
+                    }
+                ],
+                "image_url": "http://my-website.com/path/to/image.jpg",
+                "thumb_url": "http://example.com/path/to/thumb.png",
+                "footer": "Slack API",
+                "footer_icon": "https://platform.slack-edge.com/img/default_application_icon.png",
+                "ts": 123456789
+            }
+        ]
+        """
+        return []
+
+

--- a/src/app/responders/slack/__init__.py
+++ b/src/app/responders/slack/__init__.py
@@ -77,7 +77,7 @@ class SlackCommandResponder(RequestHandler, BaseResponder):
         return token in cls.TOKENS['slack']
 
     def render_response(self, args):
-        pass
+        return self.response.write(json.dumps(args))
 
     def build_attachment(self):
         """


### PR DESCRIPTION
Ok, so turns out I was incorrect in assuming the outgoing webhooks had the same response format as the slash commands. Ended up getting this output which was visible only to me:
<img width="753" alt="screen shot 2017-07-16 at 9 59 24 pm" src="https://user-images.githubusercontent.com/15634999/28255295-696d33d0-6a72-11e7-8514-57151330cad1.png">
Decided to add a new base class for slash commands. 

@gholtslander-va 